### PR TITLE
Change WorkerRoleBase to require the settings object

### DIFF
--- a/toofz.Services.Tests/StubSettings.cs
+++ b/toofz.Services.Tests/StubSettings.cs
@@ -10,6 +10,12 @@ namespace toofz.Services.Tests
         [SettingsDescription("The amount of time to wait after a cycle to perform garbage collection.")]
         public TimeSpan DelayBeforeGC { get; set; }
 
+        public void Reload()
+        {
+            UpdateInterval = default(TimeSpan);
+            DelayBeforeGC = default(TimeSpan);
+        }
+
         public void Save() { }
     }
 }

--- a/toofz.Services/Application.cs
+++ b/toofz.Services/Application.cs
@@ -10,8 +10,9 @@ namespace toofz.Services
     {
         static readonly ILog Log = LogManager.GetLogger(typeof(Application));
 
-        public static void Run<T>()
-            where T : WorkerRoleBase, new()
+        public static void Run<T, TSettings>()
+            where T : WorkerRoleBase<TSettings>, new()
+            where TSettings : ISettings
         {
             AppDomain.CurrentDomain.UnhandledException += (s, e) =>
             {

--- a/toofz.Services/ISettings.cs
+++ b/toofz.Services/ISettings.cs
@@ -14,6 +14,10 @@ namespace toofz.Services
         TimeSpan DelayBeforeGC { get; set; }
 
         /// <summary>
+        /// Refreshes the application settings property values from persistent storage.
+        /// </summary>
+        void Reload();
+        /// <summary>
         /// Stores the current values of the application settings properties.
         /// </summary>
         void Save();

--- a/toofz.Services/WorkerRoleBase.Designer.cs
+++ b/toofz.Services/WorkerRoleBase.Designer.cs
@@ -2,7 +2,7 @@
 
 namespace toofz.Services
 {
-    partial class WorkerRoleBase
+    partial class WorkerRoleBase<TSettings>
     {
         /// <summary> 
         /// Required designer variable.

--- a/toofz.Services/WorkerRoleBase.cs
+++ b/toofz.Services/WorkerRoleBase.cs
@@ -27,7 +27,7 @@ namespace toofz.Services
         #endregion
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="WorkerRoleBase"/> class.
+        /// Initializes a new instance of the <see cref="WorkerRoleBase{TSettings}"/> class.
         /// </summary>
         protected WorkerRoleBase(string serviceName)
         {

--- a/toofz.Services/packages.config
+++ b/toofz.Services/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Humanizer.Core" version="2.2.0" targetFramework="net45" />
   <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Mono.Options" version="5.3.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
+  <package id="toofz" version="5.0.4" targetFramework="net45" />
 </packages>

--- a/toofz.Services/toofz.Services.csproj
+++ b/toofz.Services/toofz.Services.csproj
@@ -33,16 +33,25 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Humanizer, Version=2.2.0.0, Culture=neutral, PublicKeyToken=979442b78dfc278e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Humanizer.Core.2.2.0\lib\netstandard1.0\Humanizer.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Options, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Options.5.3.0.1\lib\net4-client\Mono.Options.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="toofz, Version=5.0.4.151, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\toofz.5.0.4\lib\net45\toofz.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Change `WorkerRoleBase` to require the settings object instead of specific settings. `WorkerRoleBase` will also reload settings before the beginning of each cycle.