### PR TITLE
Remove OnStartOverride()

### DIFF
--- a/toofz.Services.Tests/ArgsParserTests.cs
+++ b/toofz.Services.Tests/ArgsParserTests.cs
@@ -16,7 +16,7 @@ namespace toofz.Services.Tests
             {
                 // Arrange
                 Type type = null;
-                string name = nameof(StubSettings.UpdateInterval);
+                string name = nameof(SimpleSettings.UpdateInterval);
 
                 // Act -> Assert
                 Assert.ThrowsException<ArgumentNullException>(() =>
@@ -29,7 +29,7 @@ namespace toofz.Services.Tests
             public void NameIsNull_ThrowsArgumentNullException()
             {
                 // Arrange
-                Type type = typeof(StubSettings);
+                Type type = typeof(SimpleSettings);
                 string name = null;
 
                 // Act -> Assert
@@ -43,7 +43,7 @@ namespace toofz.Services.Tests
             public void PropertyDoesNotExist_ThrowsArgumentNullException()
             {
                 // Arrange
-                Type type = typeof(StubSettings);
+                Type type = typeof(SimpleSettings);
                 string name = "!";
 
                 // Act
@@ -57,8 +57,8 @@ namespace toofz.Services.Tests
             public void NullDescription_ReturnsNull()
             {
                 // Arrange
-                Type type = typeof(StubSettings);
-                string name = nameof(StubSettings.NullDescription);
+                Type type = typeof(SimpleSettings);
+                string name = nameof(SimpleSettings.NullDescription);
 
                 // Act
                 var description = StubArgsParser.PublicGetDescription(type, name);
@@ -71,8 +71,8 @@ namespace toofz.Services.Tests
             public void MissingSettingsDescriptionAttribute_ReturnsNull()
             {
                 // Arrange
-                Type type = typeof(StubSettings);
-                string name = nameof(StubSettings.MissingSettingsDescriptionAttribute);
+                Type type = typeof(SimpleSettings);
+                string name = nameof(SimpleSettings.MissingSettingsDescriptionAttribute);
 
                 // Act
                 var description = StubArgsParser.PublicGetDescription(type, name);
@@ -277,7 +277,7 @@ namespace toofz.Services.Tests
             {
                 // Arrange
                 string[] args = new[] { "myExtraArg" };
-                settings = new StubSettings();
+                settings = new SimpleSettings();
 
                 // Act
                 parser.Parse(args, settings);

--- a/toofz.Services.Tests/SimpleSettings.cs
+++ b/toofz.Services.Tests/SimpleSettings.cs
@@ -3,7 +3,7 @@ using System.Configuration;
 
 namespace toofz.Services.Tests
 {
-    sealed class StubSettings : ISettings
+    sealed class SimpleSettings : ISettings
     {
         [SettingsDescription("The minimum amount of time that should pass between each cycle.")]
         public TimeSpan UpdateInterval { get; set; }

--- a/toofz.Services.Tests/SimpleWorkerRoleBase.cs
+++ b/toofz.Services.Tests/SimpleWorkerRoleBase.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace toofz.Services.Tests
+{
+    sealed class SimpleWorkerRoleBase : WorkerRoleBase<ISettings>
+    {
+        public SimpleWorkerRoleBase(string serviceName) : base(serviceName) { }
+
+        public override ISettings Settings => throw new NotImplementedException();
+
+        protected override Task RunAsyncOverride(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/toofz.Services.Tests/WorkerRoleBaseTests.cs
+++ b/toofz.Services.Tests/WorkerRoleBaseTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Linq;
+using System.ServiceProcess;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace toofz.Services.Tests
+{
+    class WorkerRoleBaseTests
+    {
+        [TestClass]
+        public class Constructor
+        {
+            [TestMethod]
+            public void ServiceNameIsNull_ThrowsArgumentException()
+            {
+                // Arrange
+                string serviceName = null;
+
+                // Act -> Assert
+                Assert.ThrowsException<ArgumentException>(() =>
+                {
+                    new SimpleWorkerRoleBase(serviceName);
+                });
+            }
+
+            [TestMethod]
+            public void ServiceNameContainsForwardSlash_ThrowsArgumentException()
+            {
+                // Arrange
+                string serviceName = "/";
+
+                // Act -> Assert
+                Assert.ThrowsException<ArgumentException>(() =>
+                {
+                    new SimpleWorkerRoleBase(serviceName);
+                });
+            }
+
+            [TestMethod]
+            public void ServiceNameContainsBackSlash_ThrowsArgumentException()
+            {
+                // Arrange
+                string serviceName = @"\";
+
+                // Act -> Assert
+                Assert.ThrowsException<ArgumentException>(() =>
+                {
+                    new SimpleWorkerRoleBase(serviceName);
+                });
+            }
+
+            [TestMethod]
+            public void ServiceNameIsLongerThanMaxNameLength_ThrowsArgumentException()
+            {
+                // Arrange
+                string serviceName = string.Join("", Enumerable.Repeat('a', ServiceBase.MaxNameLength + 1));
+
+                // Act -> Assert
+                Assert.ThrowsException<ArgumentException>(() =>
+                {
+                    new SimpleWorkerRoleBase(serviceName);
+                });
+            }
+        }
+    }
+}

--- a/toofz.Services.Tests/toofz.Services.Tests.csproj
+++ b/toofz.Services.Tests/toofz.Services.Tests.csproj
@@ -68,6 +68,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.ServiceProcess" />
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
@@ -92,8 +93,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArgsParserTests.cs" />
+    <Compile Include="SimpleSettings.cs" />
+    <Compile Include="SimpleWorkerRoleBase.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="StubArgsParser.cs" />
-    <Compile Include="StubSettings.cs" />
+    <Compile Include="WorkerRoleBaseTests.cs" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/toofz.Services/WorkerRoleBase.Designer.cs
+++ b/toofz.Services/WorkerRoleBase.Designer.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace toofz.Services
 {
@@ -19,6 +20,7 @@ namespace toofz.Services
         /// Clean up any resources being used.
         /// </summary>
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        [ExcludeFromCodeCoverage] // NOTE: Remove this if disposing non-designer objects.
         protected override void Dispose(bool disposing)
         {
             if (disposed)
@@ -41,6 +43,7 @@ namespace toofz.Services
         /// Required method for Designer support - do not modify 
         /// the contents of this method with the code editor.
         /// </summary>
+        [ExcludeFromCodeCoverage]
         void InitializeComponent()
         {
 

--- a/toofz.Services/WorkerRoleBase.cs
+++ b/toofz.Services/WorkerRoleBase.cs
@@ -29,13 +29,12 @@ namespace toofz.Services
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkerRoleBase{TSettings}"/> class.
         /// </summary>
+        /// <exception cref="ArgumentException">
+        /// The specified name is null or is longer than <see cref="ServiceBase.MaxNameLength"/>, 
+        /// or the specified name contains forward slash or backslash characters.
+        /// </exception>
         protected WorkerRoleBase(string serviceName)
         {
-            if (string.IsNullOrEmpty(serviceName))
-                throw new ArgumentException();
-            if (serviceName.Length > MaxNameLength)
-                throw new ArgumentException();
-
             InitializeComponent();
             ServiceName = serviceName;
         }
@@ -68,17 +67,11 @@ namespace toofz.Services
         /// or when the operating system starts (for a service that starts automatically).
         /// </summary>
         /// <param name="args">Data passed by the start command.</param>
-        protected sealed override void OnStart(string[] args)
+        protected override void OnStart(string[] args)
         {
-            OnStartOverride();
             thread = new Thread(Run);
             thread.Start();
         }
-
-        /// <summary>
-        /// When overridden in a derived class, performs initialization for the service.
-        /// </summary>
-        protected abstract void OnStartOverride();
 
         #endregion
 


### PR DESCRIPTION
Remove `OnStartOverride()`. Consumers should override `OnStart(args)` instead and call `base.OnStart(args)` after performing initialization.