### PR TITLE
Reload settings before reading instrumentation key

### DIFF
--- a/toofz.Services.Tests/ApplicationTests.cs
+++ b/toofz.Services.Tests/ApplicationTests.cs
@@ -126,6 +126,21 @@ namespace toofz.Services.Tests
             }
 
             [TestMethod]
+            public void ReloadsSettings()
+            {
+                // Arrange
+                var args = new string[0];
+                var mockSettings = new Mock<ISettings>();
+                var settings = mockSettings.Object;
+
+                // Act
+                Application.Run(args, environment, settings, worker, parser, serviceBase, log, console);
+
+                // Assert
+                mockSettings.Verify(s => s.Reload(), Times.Once);
+            }
+
+            [TestMethod]
             public void ArgsIsEmpty_DoesNotCallParse()
             {
                 // Arrange

--- a/toofz.Services.Tests/StubSettings.cs
+++ b/toofz.Services.Tests/StubSettings.cs
@@ -17,15 +17,7 @@ namespace toofz.Services.Tests
         public int NullDescription { get; set; }
         public int MissingSettingsDescriptionAttribute { get; set; }
 
-        public void Reload()
-        {
-            UpdateInterval = default(TimeSpan);
-            DelayBeforeGC = default(TimeSpan);
-            InstrumentationKey = default(string);
-            KeyDerivationIterations = default(int);
-            NullDescription = default(int);
-            MissingSettingsDescriptionAttribute = default(int);
-        }
+        public void Reload() { }
 
         public void Save() { }
     }

--- a/toofz.Services/Application.cs
+++ b/toofz.Services/Application.cs
@@ -60,6 +60,7 @@ namespace toofz.Services
             };
 
             Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
+            settings.Reload();
 
             // Args are only allowed while running as a console application as they may require user input.
             if (args.Any() && environment.UserInteractive)


### PR DESCRIPTION
This is a speculative fix. Installed services report that the instrumentation key cannot be read but other settings continue to be read correctly. This may be because the current directory is set to the system directory initially when running as a service. Settings might be attempting to load from the system directory before it gets set to the correct directory.

Fixes #21 