### PR TITLE
Revert port to .NET Standard

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 16.0.0.{build}
+version: 15.0.8.{build}
 image: Visual Studio 2017
 
 branches:

--- a/toofz.Services.Tests/toofz.Services.Tests.csproj
+++ b/toofz.Services.Tests/toofz.Services.Tests.csproj
@@ -54,7 +54,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\toofz.Services\toofz.Services.csproj">
-      <Project>{e02828fe-6ea1-4213-91fe-54c5e539678d}</Project>
+      <Project>{a80ace15-8a80-4912-aed0-385cc94b3974}</Project>
       <Name>toofz.Services</Name>
     </ProjectReference>
   </ItemGroup>

--- a/toofz.Services.sln
+++ b/toofz.Services.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2003
+VisualStudioVersion = 15.0.27004.2006
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{71A2483F-7525-444B-B67B-2C5B42E8A2D3}"
 	ProjectSection(SolutionItems) = preProject
@@ -10,7 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "toofz.Services", "toofz.Services\toofz.Services.csproj", "{E02828FE-6EA1-4213-91FE-54C5E539678D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "toofz.Services", "toofz.Services\toofz.Services.csproj", "{A80ACE15-8A80-4912-AED0-385CC94B3974}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "toofz.Services.Tests", "toofz.Services.Tests\toofz.Services.Tests.csproj", "{0F8A27E9-DF7A-4302-840A-D7A064A1EECD}"
 EndProject
@@ -20,10 +20,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E02828FE-6EA1-4213-91FE-54C5E539678D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E02828FE-6EA1-4213-91FE-54C5E539678D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E02828FE-6EA1-4213-91FE-54C5E539678D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E02828FE-6EA1-4213-91FE-54C5E539678D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A80ACE15-8A80-4912-AED0-385CC94B3974}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A80ACE15-8A80-4912-AED0-385CC94B3974}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A80ACE15-8A80-4912-AED0-385CC94B3974}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A80ACE15-8A80-4912-AED0-385CC94B3974}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0F8A27E9-DF7A-4302-840A-D7A064A1EECD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0F8A27E9-DF7A-4302-840A-D7A064A1EECD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F8A27E9-DF7A-4302-840A-D7A064A1EECD}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/toofz.Services/Properties/AssemblyInfo.cs
+++ b/toofz.Services/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("16.0.0.0")]
+[assembly: AssemblyVersion("15.0.8.0")]
 
 [assembly: AssemblyCopyright("Copyright © Leonard Thieu 2017")]
 [assembly: AssemblyProduct("toofz")]

--- a/toofz.Services/WorkerRoleBase.cs
+++ b/toofz.Services/WorkerRoleBase.cs
@@ -15,6 +15,7 @@ namespace toofz.Services
 
         private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
+        [Conditional("FEATURE_GC_ENDOFCYCLE")]
         private static void GCCollect()
         {
             GC.Collect();

--- a/toofz.Services/toofz.Services.csproj
+++ b/toofz.Services/toofz.Services.csproj
@@ -1,10 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A80ACE15-8A80-4912-AED0-385CC94B3974}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>toofz.Services</RootNamespace>
+    <AssemblyName>toofz.Services</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
   </PropertyGroup>
-
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PackageVersion>15.0.8</PackageVersion>
@@ -18,22 +25,97 @@
     <RepositoryUrl>https://github.com/leonard-thieu/toofz-services-core.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DebugType>full</DebugType>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DocumentationFile>bin\Release\netstandard2.0\toofz.Services.xml</DocumentationFile>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;FEATURE_GC_ENDOFCYCLE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;FEATURE_GC_ENDOFCYCLE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\toofz.Services.xml</DocumentationFile>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.6.0">
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="GitInfo">
+      <Version>2.0.8</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.5.0-preview1-25914-04" />
+    <PackageReference Include="log4net">
+      <Version>2.0.8</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.ApplicationInsights">
+      <Version>2.4.0</Version>
+    </PackageReference>
+    <PackageReference Include="Mono.Options">
+      <Version>5.3.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Build.Tasks.Pack">
+      <Version>4.4.0</Version>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
-
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Application.cs" />
+    <Compile Include="ConsoleApplication.cs" />
+    <Compile Include="EncryptedSecret.cs" />
+    <Compile Include="HttpClientFactory.cs" />
+    <Compile Include="IArgsParser.cs" />
+    <Compile Include="ArgsParser.cs">
+      <DependentUpon>IArgsParser.cs</DependentUpon>
+    </Compile>
+    <Compile Include="IConsoleStatic.cs" />
+    <Compile Include="ConsoleStaticAdapter.cs">
+      <DependentUpon>IConsoleStatic.cs</DependentUpon>
+    </Compile>
+    <Compile Include="IConsoleWorkerRole.cs" />
+    <Compile Include="IDirectoryStatic.cs" />
+    <Compile Include="DirectoryStaticAdapter.cs">
+      <DependentUpon>IDirectoryStatic.cs</DependentUpon>
+    </Compile>
+    <Compile Include="IIdle.cs" />
+    <Compile Include="Idle.cs">
+      <DependentUpon>IIdle.cs</DependentUpon>
+    </Compile>
+    <Compile Include="IServiceBaseStatic.cs" />
+    <Compile Include="ServiceBaseStaticAdapter.cs">
+      <DependentUpon>IServiceBaseStatic.cs</DependentUpon>
+    </Compile>
+    <Compile Include="ISettings.cs" />
+    <Compile Include="ISettingsExtensions.cs" />
+    <Compile Include="ITaskStatic.cs" />
+    <Compile Include="TaskStaticAdapter.cs">
+      <DependentUpon>ITaskStatic.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Options.cs" />
+    <Compile Include="ServiceApplication.cs" />
+    <Compile Include="ServiceSettingsProvider.cs" />
+    <Compile Include="WorkerRoleBase.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="XElementExtensions.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="IndexSource" AfterTargets="CopyFilesToOutputDirectory" Condition=" '$(APPVEYOR_REPO_NAME)' != '' ">
+    <Exec Command="nuget install SourceLink -ExcludeVersion -SolutionDirectory $(ProjectDir) -Verbosity quiet" />
+    <Exec Command="$(ProjectDir)packages\SourceLink\tools\SourceLink.exe index --proj $(ProjectPath) --proj-prop Configuration $(Configuration) --proj-prop Platform $(Platform) --url %22https://raw.githubusercontent.com/$(APPVEYOR_REPO_NAME)/{0}/%25%25var2%25%25%22 --repo $(GitRoot)" />
+  </Target>
 </Project>

--- a/toofz.Services/toofz.Services.csproj
+++ b/toofz.Services/toofz.Services.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <PackageVersion>16.0.0</PackageVersion>
+    <PackageVersion>15.0.8</PackageVersion>
     <Authors>Leonard Thieu</Authors>
     <Title>toofz Services Core</Title>
     <Description>Common code for services.</Description>


### PR DESCRIPTION
Porting to .NET Standard 2.0 with the [Windows Compatibility Pack](https://docs.microsoft.com/en-us/dotnet/core/porting/windows-compat-pack) doesn't make sense for toofz Services Core. The Windows Compatibility Pack is supposed to serve as an intermediate step for porting code to .NET Core. The expectation is that code using the Windows Compatibility Pack will eventually be rewritten to not be dependent on Windows-only technologies.

The main goal is to have toofz Services run on multiple platforms (in other words, target .NET Core). This means that having toofz Services Core target .NET Standard, while nice, isn't strictly necessary. This also leads to the main issue of `ServiceBase` not being implemented in .NET Core 2.0. Targeting .NET Standard 2.0 would allow code to compile but fail when running on .NET Core 2.0. toofz Services Core requires at minimum .NET Core 2.1 when running on .NET Core.

In addition, the Configuration API has changed significantly in .NET Core. Notably, designer support (which also generates runtime code) is not available. This affects the Settings feature in toofz Services Core. The behavior of the Configuration API on .NET Core should be verified before porting away from .NET Framework.

---

Given these issues, the goal now is to port toofz Services Core to .NET Core 2.1 when it becomes available. There is also a potential future goal of porting toofz Services Core to .NET Standard if a new version becomes available that includes the Services API.

This re-opens #31.